### PR TITLE
Fix exception when change password

### DIFF
--- a/incidents/views.py
+++ b/incidents/views.py
@@ -33,6 +33,7 @@ from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.forms.models import model_to_dict, modelform_factory
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
+from django.contrib import messages
 
 import re, datetime
 from dateutil.relativedelta import *


### PR DESCRIPTION
When changing password of user, I get an error notification but the password also be changed. Check the log I got this
```
2017-10-20 11:06:43,017: base base.py:284(handle_uncaught_exception)
Internal Server Error: /user/password/change
Traceback (most recent call last):
  File "/home/qtrr/projects/env-FIR/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 149, in get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/qtrr/projects/env-FIR/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 147, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/qtrr/projects/env-FIR/local/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 23, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/home/qtrr/projects/env-FIR/local/lib/python2.7/site-packages/django/views/decorators/http.py", line 42, in inner
    return func(request, *args, **kwargs)
  File "./incidents/views.py", line 2250, in user_change_password
    messages.success(request, "Success! Password updated.")
NameError: global name 'messages' is not defined
```

--> missing import messages

This patch add import messages as following
```python
from django.contrib import messages
```